### PR TITLE
Add Makefile for compiling and serving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,5 @@ all:
 	pelican -s pelican.conf.py content -o output
 
 chapo:
+	@echo "Making that sweet, sweet chapo"
 	cd output && python -m SimpleHTTPServer


### PR DESCRIPTION
`make` will compile the blog posts, and `make chapo` will start the python SimpleHTTPServer on port 8000.  In the long term we should probably be using the Makefile that comes with pelican, or maybe we can steal one from:

https://github.com/mbrochh/mbrochh-blog

Makefiles are funny.  We have to set the shell to bash explicitly because otherwise it uses sh (and `cd` is a bash builtin function).  Also, we have to execute the chapo command on one line, because make executes each instruction in a separate shell, and we need to be inside `output` by the time we start the HTTP server.
