### PR TITLE
Makefile: Regenerate html when making chapos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ SHELL := /bin/bash
 all:
 	pelican -s pelican.conf.py content -o output
 
-chapo:
+chapo: all
 	@echo "Making that sweet, sweet chapo"
 	cd output && python -m SimpleHTTPServer


### PR DESCRIPTION
It gets a bit tedious to make every time you wanna test... so now `make chapo` regenerates the HTML output before starting the server.
