### PR TITLE
Fix Theme Path

### DIFF
--- a/pelican.conf.py
+++ b/pelican.conf.py
@@ -34,7 +34,7 @@ SITESUBTITLE = 'Nairobi GNU/Linux Users Group'
 
 DEFAULT_PAGINATION = 10
 
-THEME = 'crowsfoot'
+THEME = 'crowsfoot/crowsfoot'
 
 # Uncomment following line if you want document-relative URLs when developing
 RELATIVE_URLS = True


### PR DESCRIPTION
Once https://github.com/nairobilug/pelican-crowsfoot/pull/4 is merged and the `crowsfoot` submodule is updated, this will fix the theme path.
