### PR TITLE
Fix header image

### DIFF
--- a/pelican.conf.py
+++ b/pelican.conf.py
@@ -29,7 +29,7 @@ SOCIAL = (
 
 # Crowsfoot settings
 GITHUB_ADDRESS = 'https://github.com/nairobilug'
-PROFILE_IMAGE_URL = '/static/images/profile.png'
+PROFILE_IMAGE_URL = '/images/profile.png'
 SITESUBTITLE = 'Nairobi GNU/Linux Users Group'
 TWITTER_ADDRESS = 'https://twitter.com/nairobilug'
 


### PR DESCRIPTION
Images from `content/images/` gets copied out by default to
`/images`.
Those making chapos have probably been seeing this ...
![no_profile](https://f.cloud.github.com/assets/3141711/1276396/2553ee26-2e64-11e3-94aa-dee7772c82dc.png)

You should now have a nice round header image like so ...
![working_profile](https://f.cloud.github.com/assets/3141711/1276397/60ab5fea-2e64-11e3-9749-b804369ad28e.png)
