### PR TITLE
pelican.conf.py: Fix STATIC_PATHS

### DIFF
--- a/pelican.conf.py
+++ b/pelican.conf.py
@@ -66,6 +66,7 @@ PAGE_URL = '{date:%Y}/{date:%m}/pages/{slug}.html'
 # Copy CNAME to output root
 STATIC_PATHS = [
     'extra/CNAME',
+    'images',
     ]
 EXTRA_PATH_METADATA = {
     'extra/CNAME': {'path': 'CNAME'},


### PR DESCRIPTION
Pelican copies `images` to $OUTPUT_DIR by default, but we're over-
riding the `STATIC_PATHS` for our CNAME stuff so we need to make
sure to copy images too.
