### PR TITLE
Makefile: Add `clean` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ all:
 chapo: all
 	@echo "Making that sweet, sweet chapo"
 	cd output && python -m SimpleHTTPServer
+
+clean:
+	rm -r output/*


### PR DESCRIPTION
Lots of cruft ends up in the output dir from past builds and config
changes, and can cause strange, seemingly random results. People
should get in the habit of cleaning often (maybe we add this to the
default make target in the future?).
