### PR TITLE
pelican.conf.py: Enable DELETE_OUTPUT_DIRECTORY

### DIFF
--- a/pelican.conf.py
+++ b/pelican.conf.py
@@ -74,3 +74,6 @@ EXTRA_PATH_METADATA = {
 
 # Enable code highlighting     
 MD_EXTENSIONS = (['codehilite(css_class=codehilite)'])    
+
+# Clean output directory during build
+DELETE_OUTPUT_DIRECTORY = True


### PR DESCRIPTION
Suggested by @kkingori.  Ensures output dir is cleaned before building, eliminating corner cases where devs had dirty output dirs and had problems reproducing bugs others were/weren't seeing.
