### PR TITLE
Default Pygments Class

### DIFF
--- a/pelican.conf.py
+++ b/pelican.conf.py
@@ -66,9 +66,6 @@ EXTRA_PATH_METADATA = {
     'extra/CNAME': {'path': 'CNAME'},
     }
 
-# Enable code highlighting     
-MD_EXTENSIONS = (['codehilite(css_class=codehilite)'])    
-
 # Clean output directory during build
 DELETE_OUTPUT_DIRECTORY = True
 


### PR DESCRIPTION
Use Pelican's default `.highlight` class for pygments
