### PR TITLE
Update Feed Options

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -15,7 +15,10 @@ TIMEZONE = 'Africa/Nairobi'
 
 # Feeds
 FEED_ATOM = 'feed/atom.xml'
-FEED_RSS = 'feed/rss.xml'
+FEED_DOMAIN = SITEURL
+FEED_ALL_ATOM = None
+CATEGORY_FEED_ATOM = None
+TRANSLATION_FEED_ATOM = None
 
 # URLs
 ARTICLE_LANG_SAVE_AS = '{date:%Y}/{date:%m}/{slug}-{lang}.html'


### PR DESCRIPTION
- Set FEED_DOMAIN option as recommended by the Pelican docs:
  http://docs.getpelican.com/en/3.3.0/settings.html#feed-settings
- Generate only one main atom feed
- Remove unused feeds generated by default
