### PR TITLE
Add Theme META_DESCRIPTION Option

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -40,6 +40,10 @@ EXTRA_PATH_METADATA = {'extra/CNAME': {'path': 'CNAME'}}
 PROFILE_IMAGE = '/images/profile.png'
 SHOW_ARTICLE_AUTHOR = True
 SITE_SUBTEXT = 'Nairobi GNU/Linux Users Group'
+META_DESCRIPTION = '''Nairobi GNU/Linux Users Group is a not-for-profit
+                   community serving the greater Nairobi area. We are a
+                   collection of people dedicated to GNU/Linux, Free Software,
+                   Open Source, and other related topics.'''
 
 # LICENSE_URL = ''
 # LICENSE_NAME = ''


### PR DESCRIPTION
Relies on feature added by https://github.com/nairobilug/pelican-alchemy/pull/10

Should fix this :expressionless:

![nairobilug-duckduckgo](https://cloud.githubusercontent.com/assets/3677497/3349192/2e8304e6-f957-11e3-90a9-0bd27640d1ec.jpg)

![nairobilug-google](https://cloud.githubusercontent.com/assets/3677497/3349193/33651c4c-f957-11e3-8dca-d1e679b365bd.jpg)
