### PR TITLE
Makefile: Allow making chapo with Python 2 or 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
 SHELL := /bin/bash
 
+python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
+python_version_major := $(word 1,${python_version_full})
+ifeq ($(python_version_major),2)
+	build_cmd := python -m SimpleHTTPServer
+else
+	build_cmd := python -m http.server
+endif
+
 all:
 	pelican content
 
 chapo: all
 	@echo "Making that sweet, sweet chapo"
-	cd output && python -m SimpleHTTPServer
+	cd output && ${build_cmd}
 
 clean:
 	rm -r output/*


### PR DESCRIPTION
At the meetup I noticed @highPriestLOL wasn't able to `make chapo` with Python 3, and that's a crying shame. Python 3 uses `http.server` instead of `SimpleHTTPServer`. Python 3 is at 3.4 now, and it's much faster and starting to be on most distros as the default now, so we should definitely just do this.