### PR TITLE
Makefile: Add "PHONY" targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,5 @@ chapo: all
 
 clean:
 	rm -r output/*
+
+.PHONY: all chapo clean


### PR DESCRIPTION
If you tell make to `make clean` then it actually looks for a file called "clean" in the current directory. For example:

    $ touch clean
    $ make clean
    make: 'clean' is up to date.

.PHONY tells make that the named targets don't have corresponding files in the file system and to just run their targets explicitly.