### PR TITLE
requirements.txt: Bump Pelican requirement to 3.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ghp-import
 markdown
-pelican>=3.5
+pelican==3.6.2


### PR DESCRIPTION
Latest version of Pelican is 3.6.2, so we might as well require it.