### PR TITLE
Convert blog post titles to "title case"

### DIFF
--- a/content/ansible-api-reporting.md
+++ b/content/ansible-api-reporting.md
@@ -1,4 +1,4 @@
-Title: Leveraging the Ansible Python API for infrastructure reporting
+Title: Leveraging the Ansible Python API for Infrastructure Reporting
 Date: 2015-01-21 16:40
 Category: Linux
 Tags: linux, ansible

--- a/content/ansible-shellshock.md
+++ b/content/ansible-shellshock.md
@@ -1,4 +1,4 @@
-Title: Update hosts via Ansible to mitigate bash "Shellshock" vulnerability
+Title: Update Hosts via Ansible to Mitigate Bash "Shellshock" Vulnerability
 Date: 2014-09-29 10:40
 Category: Linux
 Tags: linux, ansible, bash, security

--- a/content/brck-violating-gpl.md
+++ b/content/brck-violating-gpl.md
@@ -1,4 +1,4 @@
-Title: BRCK in violation of the GPL
+Title: BRCK in Violation of the GPL
 Date: 2015-05-18 15:21
 Category: Licensing
 Tags: licensing, gpl

--- a/content/cron-systemd-timers.md
+++ b/content/cron-systemd-timers.md
@@ -1,4 +1,4 @@
-Title: Replacing cron jobs with systemd timers
+Title: Replacing Cron Jobs With Systemd Timers
 Date: 2015-06-08 15:21
 Category: Linux
 Tags: linux, systemd, cron

--- a/content/experimenting-with-aes-ni.md
+++ b/content/experimenting-with-aes-ni.md
@@ -1,4 +1,4 @@
-Title: Experimenting with AES-NI
+Title: Experimenting With AES-NI
 Date: 2013-11-10 13:00
 Category: Linux
 Tags: linux, crypto

--- a/content/exploring-dos-mitigation-in-apache-httpd.md
+++ b/content/exploring-dos-mitigation-in-apache-httpd.md
@@ -1,4 +1,4 @@
-Title: Exploring anti-DOS tools for Apache httpd
+Title: Exploring Anti-DOS Tools for Apache Httpd
 Date: 2014-09-13 18:28
 Category: Linux
 Tags: linux, security, httpd, nginx

--- a/content/image-compression-open-source.md
+++ b/content/image-compression-open-source.md
@@ -1,4 +1,4 @@
-Title: Image compression like Compressor.io, but with open-source tools
+Title: Image Compression Like Compressor.io, but With Open-Source Tools
 Date: 2014-10-23 10:40
 Category: Linux
 Tags: linux, images, photography

--- a/content/in_the_spirit_of_pelican.md
+++ b/content/in_the_spirit_of_pelican.md
@@ -1,4 +1,4 @@
-Title: In The Spirit of Pelican
+Title: In the Spirit of Pelican
 Date: 2013-07-14 20:22
 Category: Pelican
 Tags: pelican, publishing

--- a/content/maps-and-custom-error-pages-nginx.md
+++ b/content/maps-and-custom-error-pages-nginx.md
@@ -1,4 +1,4 @@
-Title: Maps and custom error pages in nginx
+Title: Maps and Custom Error Pages in Nginx
 Date: 2014-12-09 17:00
 Category: Linux
 Tags: linux, nginx

--- a/content/openstack-swift.md
+++ b/content/openstack-swift.md
@@ -1,4 +1,4 @@
-Title: Using swiftclient for object storage on OpenStack
+Title: Using Swiftclient for Object Storage on OpenStack
 Date: 2014-07-29 19:40
 Category: Linux
 Tags: linux, openstack, swift

--- a/content/parallelizing-rsync.md
+++ b/content/parallelizing-rsync.md
@@ -1,4 +1,4 @@
-Title: Parallelizing rsync
+Title: Parallelizing Rsync
 Date: 2014-07-11 16:40
 Category: Linux
 Tags: linux, rsync

--- a/content/pushing-two-git-remotes.md
+++ b/content/pushing-two-git-remotes.md
@@ -1,4 +1,4 @@
-Title: Simultaneously pushing to two remotes in a git repository
+Title: Simultaneously Pushing to Two Remotes in a Git Repository
 Date: 2015-05-10 16:40
 Category: Linux
 Tags: linux, git

--- a/content/ramping-up-ethiopia-lug.md
+++ b/content/ramping-up-ethiopia-lug.md
@@ -1,4 +1,4 @@
-Title: Ramping up the Ethiopia LUG
+Title: Ramping Up the Ethiopia LUG
 Date: 2015-04-25 21:01
 Category: Meetups
 Tags: meetup

--- a/content/rebooting-server-using-ansible.md
+++ b/content/rebooting-server-using-ansible.md
@@ -1,4 +1,4 @@
-Title: Rebooting server(s) using Ansible
+Title: Rebooting Server(s) Using Ansible
 Date: 2015-03-03 12:35
 Category: Linux
 Tags: linux, ansible

--- a/content/sctp-protocol.md
+++ b/content/sctp-protocol.md
@@ -1,4 +1,4 @@
-Title: The "SCTP" protocol
+Title: The "SCTP" Protocol
 Date: 2014-09-04 18:37
 Category: Tech
 Tags: Tech, Linux, programming

--- a/content/stop-pulseaudio-uncorking.md
+++ b/content/stop-pulseaudio-uncorking.md
@@ -1,4 +1,4 @@
-Title: Stop Skype and PulseAudio from "uncorking" media players
+Title: Stop Skype and PulseAudio From "Uncorking" Media Players
 Date: 2015-08-02 15:21
 Category: Linux
 Tags: linux, pulseaudio, skype, nsa

--- a/content/systemd-mount-partition.md
+++ b/content/systemd-mount-partition.md
@@ -1,4 +1,4 @@
-Title: Mounting Partitions Using Systemd
+Title: Mounting Partitions Using systemd
 Date: 2015-09-02 11:00
 Category: Linux
 Tags: linux, systemd

--- a/content/systemd-mount-partition.md
+++ b/content/systemd-mount-partition.md
@@ -1,4 +1,4 @@
-Title: Mounting Partitions Using systemd
+Title: Mounting Partitions Using Systemd
 Date: 2015-09-02 11:00
 Category: Linux
 Tags: linux, systemd


### PR DESCRIPTION
Closes #138. Quick script that did it:

```shell
#!/usr/bin/env bash

POST_FILES=$(find content/ -name "*.md")
POST_REGEX='(?<=Title: )(.+)'

for i in $POST_FILES; do
  POST_TITLE=$(pcregrep -o "$POST_REGEX" "$i") # brew install pcre
  POST_TCASE=$(titlecase <<< "$POST_TITLE") # brew install titlecase
  perl -i -pe "s/$POST_REGEX/$POST_TCASE/" "$i" # search / replace
done
```