### PR TITLE
Makefile from the Pelican 3.6.3 pelican-quickstart script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,123 @@
-SHELL := /bin/bash
+PY?=python
+PELICAN?=pelican
+PELICANOPTS=
 
-python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
-python_version_major := $(word 1,${python_version_full})
-ifeq ($(python_version_major),2)
-	build_cmd := python -m SimpleHTTPServer
-else
-	build_cmd := python -m http.server
+BASEDIR=$(CURDIR)
+INPUTDIR=$(BASEDIR)/content
+OUTPUTDIR=$(BASEDIR)/output
+CONFFILE=$(BASEDIR)/pelicanconf.py
+PUBLISHCONF=$(BASEDIR)/publishconf.py
+
+FTP_HOST=localhost
+FTP_USER=anonymous
+FTP_TARGET_DIR=/
+
+SSH_HOST=localhost
+SSH_PORT=22
+SSH_USER=root
+SSH_TARGET_DIR=/var/www
+
+S3_BUCKET=my_s3_bucket
+
+CLOUDFILES_USERNAME=my_rackspace_username
+CLOUDFILES_API_KEY=my_rackspace_api_key
+CLOUDFILES_CONTAINER=my_cloudfiles_container
+
+DROPBOX_DIR=~/Dropbox/Public/
+
+GITHUB_PAGES_BRANCH=gh-pages
+
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+	PELICANOPTS += -D
 endif
 
-all:
-	pelican content
+RELATIVE ?= 0
+ifeq ($(RELATIVE), 1)
+	PELICANOPTS += --relative-urls
+endif
 
-chapo: all
-	@echo "Making that sweet, sweet chapo"
-	cd output && ${build_cmd}
+help:
+	@echo 'Makefile for a pelican Web site                                           '
+	@echo '                                                                          '
+	@echo 'Usage:                                                                    '
+	@echo '   make html                           (re)generate the web site          '
+	@echo '   make clean                          remove the generated files         '
+	@echo '   make regenerate                     regenerate files upon modification '
+	@echo '   make publish                        generate using production settings '
+	@echo '   make serve [PORT=8000]              serve site at http://localhost:8000'
+	@echo '   make serve-global [SERVER=0.0.0.0]  serve (as root) to $(SERVER):80    '
+	@echo '   make devserver [PORT=8000]          start/restart develop_server.sh    '
+	@echo '   make stopserver                     stop local server                  '
+	@echo '   make ssh_upload                     upload the web site via SSH        '
+	@echo '   make rsync_upload                   upload the web site via rsync+ssh  '
+	@echo '   make dropbox_upload                 upload the web site via Dropbox    '
+	@echo '   make ftp_upload                     upload the web site via FTP        '
+	@echo '   make s3_upload                      upload the web site via S3         '
+	@echo '   make cf_upload                      upload the web site via Cloud Files'
+	@echo '   make github                         upload the web site via gh-pages   '
+	@echo '                                                                          '
+	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html   '
+	@echo 'Set the RELATIVE variable to 1 to enable relative urls                    '
+	@echo '                                                                          '
+
+html:
+	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
 
 clean:
-	rm -r output/*
+	[ ! -d $(OUTPUTDIR) ] || rm -rf $(OUTPUTDIR)
 
-.PHONY: all chapo clean
+regenerate:
+	$(PELICAN) -r $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+
+serve:
+ifdef PORT
+	cd $(OUTPUTDIR) && $(PY) -m pelican.server $(PORT)
+else
+	cd $(OUTPUTDIR) && $(PY) -m pelican.server
+endif
+
+serve-global:
+ifdef SERVER
+	cd $(OUTPUTDIR) && $(PY) -m pelican.server 80 $(SERVER)
+else
+	cd $(OUTPUTDIR) && $(PY) -m pelican.server 80 0.0.0.0
+endif
+
+devserver:
+ifdef PORT
+	$(BASEDIR)/develop_server.sh restart $(PORT)
+else
+	$(BASEDIR)/develop_server.sh restart
+endif
+
+stopserver:
+	$(BASEDIR)/develop_server.sh stop
+	@echo 'Stopped Pelican and SimpleHTTPServer processes running in background.'
+
+publish:
+	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS)
+
+ssh_upload: publish
+	scp -P $(SSH_PORT) -r $(OUTPUTDIR)/* $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
+
+rsync_upload: publish
+	rsync -e "ssh -p $(SSH_PORT)" -P -rvzc --delete $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR) --cvs-exclude
+
+dropbox_upload: publish
+	cp -r $(OUTPUTDIR)/* $(DROPBOX_DIR)
+
+ftp_upload: publish
+	lftp ftp://$(FTP_USER)@$(FTP_HOST) -e "mirror -R $(OUTPUTDIR) $(FTP_TARGET_DIR) ; quit"
+
+s3_upload: publish
+	s3cmd sync $(OUTPUTDIR)/ s3://$(S3_BUCKET) --acl-public --delete-removed --guess-mime-type
+
+cf_upload: publish
+	cd $(OUTPUTDIR) && swift -v -A https://auth.api.rackspacecloud.com/v1.0 -U $(CLOUDFILES_USERNAME) -K $(CLOUDFILES_API_KEY) upload -c $(CLOUDFILES_CONTAINER) .
+
+github: publish
+	ghp-import -m "Generate Pelican site" -b $(GITHUB_PAGES_BRANCH) $(OUTPUTDIR)
+	git push origin $(GITHUB_PAGES_BRANCH)
+
+.PHONY: html help clean regenerate serve serve-global devserver publish ssh_upload rsync_upload dropbox_upload ftp_upload s3_upload cf_upload github

--- a/develop_server.sh
+++ b/develop_server.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+##
+# This section should match your Makefile
+##
+
+PY=${PY:-python}
+PELICAN=${PELICAN:-pelican}
+PELICANOPTS=
+
+BASEDIR=$(pwd)
+INPUTDIR=$BASEDIR/content
+OUTPUTDIR=$BASEDIR/output
+CONFFILE=$BASEDIR/pelicanconf.py
+
+###
+# Don't change stuff below here unless you are sure
+###
+
+SRV_PID=$BASEDIR/srv.pid
+PELICAN_PID=$BASEDIR/pelican.pid
+
+function usage(){
+  echo "usage: $0 (stop) (start) (restart) [port]"
+  echo "This starts Pelican in debug and reload mode and then launches"
+  echo "an HTTP server to help site development. It doesn't read"
+  echo "your Pelican settings, so if you edit any paths in your Makefile"
+  echo "you will need to edit your settings as well."
+  exit 3
+}
+
+function alive() {
+  kill -0 $1 >/dev/null 2>&1
+}
+
+function shut_down(){
+  PID=$(cat $SRV_PID)
+  if [[ $? -eq 0 ]]; then
+    if alive $PID; then
+      echo "Stopping HTTP server"
+      kill $PID
+    else
+      echo "Stale PID, deleting"
+    fi
+    rm $SRV_PID
+  else
+    echo "HTTP server PIDFile not found"
+  fi
+
+  PID=$(cat $PELICAN_PID)
+  if [[ $? -eq 0 ]]; then
+    if alive $PID; then
+      echo "Killing Pelican"
+      kill $PID
+    else
+      echo "Stale PID, deleting"
+    fi
+    rm $PELICAN_PID
+  else
+    echo "Pelican PIDFile not found"
+  fi
+}
+
+function start_up(){
+  local port=$1
+  echo "Starting up Pelican and HTTP server"
+  shift
+  $PELICAN --debug --autoreload -r $INPUTDIR -o $OUTPUTDIR -s $CONFFILE $PELICANOPTS &
+  pelican_pid=$!
+  echo $pelican_pid > $PELICAN_PID
+  cd $OUTPUTDIR
+  $PY -m pelican.server $port &
+  srv_pid=$!
+  echo $srv_pid > $SRV_PID
+  cd $BASEDIR
+  sleep 1
+  if ! alive $pelican_pid ; then
+    echo "Pelican didn't start. Is the Pelican package installed?"
+    return 1
+  elif ! alive $srv_pid ; then
+    echo "The HTTP server didn't start. Is there another service using port" $port "?"
+    return 1
+  fi
+  echo 'Pelican and HTTP server processes now running in background.'
+}
+
+###
+#  MAIN
+###
+
+[[ ($# -eq 0) || ($# -gt 2) ]] && usage
+port=''
+[[ $# -eq 2 ]] && port=$2
+
+if [[ $1 == "stop" ]]; then
+  shut_down
+elif [[ $1 == "restart" ]]; then
+  shut_down
+  start_up $port
+elif [[ $1 == "start" ]]; then
+  if ! start_up $port; then
+    shut_down
+  fi
+else
+  usage
+fi

--- a/publishconf.py
+++ b/publishconf.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+# This file is only used if you use `make publish` or explicitly specify it as
+# your config file.
+
+import os
+import sys
+sys.path.append(os.curdir)
+from pelicanconf import *
+
+
+SITEURL = 'https://nairobilug.or.ke'
+RELATIVE_URLS = False
+
+FEED_ALL_ATOM = 'feeds/all.atom.xml'
+CATEGORY_FEED_ATOM = 'feeds/%s.atom.xml'
+
+DELETE_OUTPUT_DIRECTORY = True
+
+# Following items are often useful when publishing
+# DISQUS_SITENAME = ''
+# GOOGLE_ANALYTICS = ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-ghp-import
-markdown
-pelican==3.6.2
+Markdown
+pelican==3.6.*


### PR DESCRIPTION
http://docs.getpelican.com/en/3.6.3/publish.html#automation

Closes #148. Comes with nice development and deploy tools: 

```
$ make
Makefile for a pelican Web site

Usage:
   make html                           (re)generate the web site
   make clean                          remove the generated files
   make regenerate                     regenerate files upon modification
   make publish                        generate using production settings
   make serve [PORT=8000]              serve site at http://localhost:8000
   make serve-global [SERVER=0.0.0.0]  serve (as root) to :80
   make devserver [PORT=8000]          start/restart develop_server.sh
   make stopserver                     stop local server
   make ssh_upload                     upload the web site via SSH
   make rsync_upload                   upload the web site via rsync+ssh
   make dropbox_upload                 upload the web site via Dropbox
   make ftp_upload                     upload the web site via FTP
   make s3_upload                      upload the web site via S3
   make cf_upload                      upload the web site via Cloud Files
   make github                         upload the web site via gh-pages

Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html
Set the RELATIVE variable to 1 to enable relative urls
```