### PR TITLE
Add the October 2016 Meetup Summary

### DIFF
--- a/content/meetup-october-2016.md
+++ b/content/meetup-october-2016.md
@@ -1,0 +1,36 @@
+Title: Meetup Summary (October, 2016)
+Date: 2016-10-03 11:30
+Category: Meetups
+Tags: meetup
+Slug: meetup-october-2016
+Author: Frederick Muriithi,
+Summary: Highlights from the October, 2016 meetup.
+
+The Linux User Group is still going strong, despite the various instances that people may have mused that it is dying. The attendance was something to be proud of, and in the spirit of that, this article shall have multiple authors, to reflect the various things that were spoken about in the various enclaves that rose up.
+
+## Growth Pains
+
+There was a discussion on the next step that the LUG needs to take. The question was poised to zipper: "You are at a gathering of sorts (conference, summit, etc.) and they introduce you, 'Ladies and gentlement, today we have among us [zipper's real name] from nairobilug, to tell us who/what nairobilug is and what they do.' Go!"
+
+Hilarity ensued!
+
+None of us, were able to indicate what exactly we do, besides 'meeting and having fun'. Sure, we discuss Open-Source Software, the current shenanigans the government, politicians, local institutions and businesses are up to. We even hustled [BRCK][brck] a [while back](https://nairobilug.or.ke/2015/05/brck-violating-gpl.html) and got them to come out and explain themselves.
+
+They also gave us one BRCK for our examination, and an agreement was reached that we would do a writeup on the same. This writeup, is non-existent todate.
+
+The next issue raise to illustrate the point was the recent, IT Practitioners bill that was being debated in parliament. The question was asked, why it is the LUG was not asked for its opinion.
+
+The conclusion was, we, as the LUG, are invisible, and a non-issue in the running of tech, and anything related, since we have not shown ourselves worthy of it. We can spend time bitching and moaning about [iHub][ihub] and other tech-related groupings, companies, etc, but we have not shown another way of doing it, correct or otherwise.
+
+It was thus proposed to figure out what it is we can do as a group, that is useful to the general public in the country, so that we can grow, as a group, and also, so that we can even be taken seriously in the tech community in the country.
+
+## Leave Your Devs Alone
+
+An instance came up, where a member handed in a resignation letter to the management, due to the way they kept getting interrupted at work every few minutes over mundane and inane concerns. The resignation letter was a wake-up call to the management, who have since reformed, and the whole saga had a fairy-tale ending (did it?)
+
+This has been written about previously, by many, more prominent developers and CEOs, that this should not be happening in 2016, but it still is...
+
+## Other Topics
+
+[brck](https://www.brck.com/)
+[ihub](https://www.ihub.co.ke/)


### PR DESCRIPTION
- Initialise the October 2016 Meetup Summary article, and let it
  be a multi-author project, so as to capture as much of what
  was discussed as possible
