### PR TITLE
Update Pelican 3.6.3 -> 3.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ghp-import==0.4.1
 Markdown==2.6.7
-pelican==3.6.3
+pelican==3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ghp-import==0.4.1
-Markdown==2.6.7
+ghp-import
+Markdown
 pelican==3.7.0


### PR DESCRIPTION
And don't lock down `ghp-import` or `Markdown` versions - less likely to break.