### PR TITLE
Remove duplicate variables on pelican-bootstrapify

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -49,15 +49,6 @@ BOOTSTRAPIFY = {
     'blockquote': ['blockquote'],
 }
 
-PLUGIN_PATHS = ['plugins']
-PLUGINS = ['pelican-bootstrapify']
-
-BOOTSTRAPIFY = {
-    'table': ['table', 'table-striped', 'table-hover'],
-    'img': ['img-fluid'],
-    'blockquote': ['blockquote'],
-}
-
 # Theme settings --------------------------------------------------------------
 
 THEME = 'themes/pelican-alchemy/alchemy'


### PR DESCRIPTION
This is to remove some duplicate vars I saw in the pelicanconf.py

Signed-off-by: BonfaceKilz <bonfacemunyoki@gmail.com>