### PR TITLE
Update references to Freenode with libera.chat and remove Google Plus link.

### DIFF
--- a/content/pages/about-us.md
+++ b/content/pages/about-us.md
@@ -6,7 +6,7 @@ The Nairobi GNU/Linux Users Group (NairobiLUG) is a not-for-profit community ser
 
 We traditionally meet on the first Saturday of every month between 16:00 ~ 18:00 EAT (GMT +3) at KFC Kimathi Street. All meetups are free and open to the public.
 
-You can join our [mailing list]({filename}/pages/mailing-list.md), where meetups are announced and other general LUG conversation takes place. You can also follow us on [Twitter](https://twitter.com/nairobilug). Lastly if you prefer a more real-time medium, you can chat to us on IRC. We're on the Freenode network and the channel name is [#nairobilug](irc://chat.freenode.net/#nairobilug). Details are listed on our [contact page]({filename}/pages/contact.md).
+You can join our [mailing list]({filename}/pages/mailing-list.md), where meetups are announced and other general LUG conversation takes place. You can also follow us on [Twitter](https://twitter.com/nairobilug). Lastly if you prefer a more real-time medium, you can chat to us on IRC. We're on the Freenode network and the channel name is [#nairobilug](irc://libera.chat/#nairobilug). Details are listed on our [contact page]({filename}/pages/contact.md).
 
 **There is no level of technical expertise required to attend meetups** and we pride ourselves on being open and friendly to all. We're just as likely to be found talking about the latest film releases, music or anything else as hardcore techy topics.
 

--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -6,11 +6,11 @@ Online, we primarily communicate through an email [mailing list]({filename}/page
 
 ## Internet Relay Chat
 
-The LUG has an IRC channel which everyone (especially members) is welcome to join. If you are new to IRC, you can connect through freenode's [Web IRC](http://webchat.freenode.net/?channels=nairobilug).
+The LUG has an IRC channel which everyone (especially members) is welcome to join. If you are new to IRC, you can connect through freenode's [Web IRC](https://web.libera.chat/?channels=nairobilug).
 
-- Network: [freenode.net](https://freenode.net/)
-- Channel: [#nairobilug](irc://chat.freenode.net/#nairobilug)
+- Network: [Libera.caht](https://libera.chat)
+- Channel: [#nairobilug](irc://libera.chat/#nairobilug)
 
 ## Social Media
 
-Find us around the web in the following places: [Google+](https://plus.google.com/u/0/communities/107260210367217532462), [Twitter](https://twitter.com/nairobilug)
+Find us around the web in the following places: [Twitter](https://twitter.com/nairobilug)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -60,7 +60,7 @@ DESCRIPTION = 'A not-for-profit community serving the greater Nairobi area. ' \
               'Software, Open Source, and related topics.'
 
 LINKS = (
-    ('IRC', 'https://webchat.freenode.net/?channels=nairobilug'),
+    ('IRC', 'https://web.libera.chat/?channels=nairobilug'),
 )
 
 ICONS = [


### PR DESCRIPTION
Addresses issue comment raised by @jnduli on https://github.com/nairobilug/nairobilug.or.ke/issues/193#issuecomment-865024411.

Also removes Google Plus link as the service is already dead.

![Screenshot from 2021-06-21 17-32-48](https://user-images.githubusercontent.com/10687877/122782994-d9cff780-d2b9-11eb-8cc8-2611b0f0fde0.png)

