### PR TITLE
Fix build error by pinning Jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ghp-import
 Markdown
 pelican==3.7.1
 bs4 # pelican-bootstrapify
+Jinja2==3.0.3


### PR DESCRIPTION
Jinja `3.1.0` changes how `Markup` should be imported resulting in this error
```
ImportError: cannot import name 'Markup' from 'jinja2'
```
Pinning it to version `3.0.3` fixes it

https://jinja.palletsprojects.com/en/3.1.x/changes/?highlight=markup#version-3-1-0