### PR TITLE
Point the LUG website URLs to the new acquired url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nairobi GNU/Linux Users Group Website
 
-This repository hosts the code for the [Nairobi GNU/Linux Users Group](https://nairobilug.or.ke) website. We wanted a fun, nerdy and democratic way to give our community an online presence, so here we are.
+This repository hosts the code for the [Nairobi GNU/Linux Users Group](https://nairobi.lug.or.ke) website. We wanted a fun, nerdy and democratic way to give our community an online presence, so here we are.
 
 ![Screenshot](screenshot.jpg "Screenshot")
 

--- a/content/brck-violating-gpl.md
+++ b/content/brck-violating-gpl.md
@@ -6,7 +6,7 @@ Slug: brck-violating-gpl
 Author: Alan Orth
 Summary: BRCK is distributing binaries derived from GPL-licensed programs and fails to comply with the copyleft obligations of the license.
 
-During a recent meeting of the Nairobi GNU/Linux Users Group we discussed [BRCK](https://www.brck.com "BRCK | Rugged, Portable WiFi Hotspot & Battery Extender"), the Kenya-based makers of a slick, "rugged", battery-powered-GSM-router thing of the same name, and their apparent violation of the GNU General Public License (GPL). The lively discussion ended up making its way to the web in the form of a [blog post](https://nairobilug.or.ke/2015/05/meetup-may-2015.html) on the group's blog.
+During a recent meeting of the Nairobi GNU/Linux Users Group we discussed [BRCK](https://www.brck.com "BRCK | Rugged, Portable WiFi Hotspot & Battery Extender"), the Kenya-based makers of a slick, "rugged", battery-powered-GSM-router thing of the same name, and their apparent violation of the GNU General Public License (GPL). The lively discussion ended up making its way to the web in the form of a [blog post](https://nairobi.lug.or.ke/2015/05/meetup-may-2015.html) on the group's blog.
 
 Their product is based on [OpenWRT](https://openwrt.org/) — the GNU/Linux distribution geared towards embedded systems — which is [licensed](http://wiki.openwrt.org/about/license) under the GPL v2. I believe this is problematic for BRCK for a number of reasons that I will enumerate below. When we reached out to BRCK they claimed that they were not in violation because they use "stock unmodified OpenWRT" source code. This claim is repeated verbatim in a [thread on their forum](http://forums.brck.com/t/where-is-the-openwrt-fork-source-at/482/8).
 

--- a/content/letsencrypt-systemd-timers.md
+++ b/content/letsencrypt-systemd-timers.md
@@ -6,7 +6,7 @@ Slug: using-systemd-timers-to-renew-lets-encrypt-certificates
 Author: Alan Orth
 Summary: Automating the Let's Encrypt TLS certificate renewal process using systemd timers on GNU/Linux is easier and more flexible than using cron.
 
-This is a quick blog post to share the systemd timers that I use to automate the renewal of my [Let's Encrypt](https://letsencrypt.org) certificates. I prefer [systemd timers to cron jobs](https://nairobilug.or.ke/2015/06/cron-systemd-timers.html) for task scheduling because they are more flexible and easier to debug. I assume that you know what Let's Encrypt is and that you already have some certificates. If not, I recommend that you check out [Certbot](https://certbot.eff.org) (the official reference client) and get some.
+This is a quick blog post to share the systemd timers that I use to automate the renewal of my [Let's Encrypt](https://letsencrypt.org) certificates. I prefer [systemd timers to cron jobs](https://nairobi.lug.or.ke/2015/06/cron-systemd-timers.html) for task scheduling because they are more flexible and easier to debug. I assume that you know what Let's Encrypt is and that you already have some certificates. If not, I recommend that you check out [Certbot](https://certbot.eff.org) (the official reference client) and get some.
 
 [![Let's Encrypt logo]({filename}/images/letsencrypt-systemd-timers/lets-encrypt.png)](https://letsencrypt.org/ "Let's Encrypt homepage")
 

--- a/content/meetup-july-2015.md
+++ b/content/meetup-july-2015.md
@@ -25,7 +25,7 @@ Someone also pointed out that one of the Universities is still teaching HTML 2.0
 
 ### Hackathons, Conferences, etc
 
-There was a slight segway into talks about various conferences, and how in Kenya, there seems to be a dearth of information on things like venues and times. Someone suggested that the organisers might be afraid that the NairobiLUG might criticise them [as it did BRCK](https://nairobilug.or.ke/2015/05/brck-violating-gpl.html).
+There was a slight segway into talks about various conferences, and how in Kenya, there seems to be a dearth of information on things like venues and times. Someone suggested that the organisers might be afraid that the NairobiLUG might criticise them [as it did BRCK](https://nairobi.lug.or.ke/2015/05/brck-violating-gpl.html).
 
 We laughed that off as unlikely and quickly moved on.
 

--- a/content/meetup-june-2015.md
+++ b/content/meetup-june-2015.md
@@ -16,7 +16,7 @@ They've even got some of the nuts and bolts for provisioning and managing this p
 
 ### BRCK
 
-After [last month's](https://nairobilug.or.ke/2015/05/meetup-may-2015.html) discussion of [BRCK's GPL violation](https://nairobilug.or.ke/2015/05/brck-violating-gpl.html) BRCK reached out to us and resolved things amicably. In addition to posting [source code for their BRCKv1](https://www.brck.com/open-source-compliance/) a few of their people came to the meetup to talk about OpenWRT, single-board computers, and fried chicken.
+After [last month's](https://nairobi.lug.or.ke/2015/05/meetup-may-2015.html) discussion of [BRCK's GPL violation](https://nairobi.lug.or.ke/2015/05/brck-violating-gpl.html) BRCK reached out to us and resolved things amicably. In addition to posting [source code for their BRCKv1](https://www.brck.com/open-source-compliance/) a few of their people came to the meetup to talk about OpenWRT, single-board computers, and fried chicken.
 
 Furthermore, we discussed the role that the community can play in getting the word about companies that are friendly to open-source hardware and software. Simple things like how to flash vanilla software for devices, where to get source code, how to set up a build environment, unbricking, teardowns, etc. In that light, BRCK has donated one BRCKv1 unit to the LUG so we can pass it around, hack on it, and write about it.
 

--- a/content/meetup-october-2016.md
+++ b/content/meetup-october-2016.md
@@ -14,7 +14,7 @@ There was a discussion on the next step that the LUG needs to take. The question
 
 Hilarity ensued!
 
-None of us, were able to indicate what exactly we do, besides 'meeting and having fun'. Sure, we discuss Open-Source Software, the current shenanigans the government, politicians, local institutions and businesses are up to. We even hustled [BRCK](https://www.brck.com/) a [while back](https://nairobilug.or.ke/2015/05/brck-violating-gpl.html) and got them to come out and explain themselves.
+None of us, were able to indicate what exactly we do, besides 'meeting and having fun'. Sure, we discuss Open-Source Software, the current shenanigans the government, politicians, local institutions and businesses are up to. We even hustled [BRCK](https://www.brck.com/) a [while back](https://nairobi.lug.or.ke/2015/05/brck-violating-gpl.html) and got them to come out and explain themselves.
 
 They also gave us one BRCK for our examination, and an agreement was reached that we would do a writeup on the same. This writeup, is non-existent to-date.
 

--- a/content/redirecting-http-traffic-while-using-aws-target-groups.md
+++ b/content/redirecting-http-traffic-while-using-aws-target-groups.md
@@ -238,7 +238,7 @@ We started with a broken configuration that put a small subset of HTTP requests 
 [HSTS Preload List Submission]: https://hstspreload.org
 [Onadata API]: http://github.com/onaio/onadata
 [HTTPS Everywhere]: https://www.eff.org/HTTPS-Everywhere
-[Nairobi Linux Users Group]: https://nairobilug.or.ke/
+[Nairobi Linux Users Group]: https://nairobi.lug.or.ke/
 [HSTS]: https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
 [From Wikipedia]: https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
 [here]: https://github.com/onaio/milia/blob/580969b2b2a88a446b5d903237adca7ab4003096/src/milia/api/io.cljs#L119


### PR DESCRIPTION
We weren't able to renew the original domain.  @bkmgit was gracious enough to acquire another domain to host the website.  This PR points the URLs to this new home.  In the meantime, I want to come up with an RFC for how resources are managed within the LUG.